### PR TITLE
feat(nixos): add disko partition management for kong

### DIFF
--- a/configurations/nixos/kong/configuration.nix
+++ b/configurations/nixos/kong/configuration.nix
@@ -22,6 +22,11 @@ in
   };
 
   boot = {
+    initrd = {
+      supportedFilesystems = [ "ext4" ];
+      checkJournalingFS = true;
+    };
+
     loader = {
       systemd-boot = {
         # Use the systemd-boot EFI boot loader.

--- a/configurations/nixos/kong/default.nix
+++ b/configurations/nixos/kong/default.nix
@@ -11,6 +11,8 @@
       inputs.nixos-hardware.nixosModules.common-pc-ssd
       inputs.nix-index-database.nixosModules.nix-index
       inputs.home-manager.nixosModules.home-manager
+      inputs.disko.nixosModules.disko
+      ./disko.nix
 
       {
         nixpkgs = {

--- a/configurations/nixos/kong/disko.nix
+++ b/configurations/nixos/kong/disko.nix
@@ -1,0 +1,68 @@
+{
+  disko.devices.disk.main = {
+    type = "disk";
+    device = "/dev/nvme0n1";
+    content = {
+      type = "gpt";
+      partitions = {
+        ESP = {
+          size = "512M";
+          type = "EF00";
+          content = {
+            type = "filesystem";
+            format = "vfat";
+            mountpoint = "/boot";
+            mountOptions = [ "umask=0077" ];
+          };
+        };
+        key = {
+          size = "40M";
+          content = {
+            type = "luks";
+            name = "cryptkey";
+            settings.allowDiscards = true;
+          };
+        };
+        swap = {
+          size = "32G";
+          content = {
+            type = "luks";
+            name = "cryptswap";
+            settings = {
+              allowDiscards = true;
+              keyFile = "/dev/mapper/cryptkey";
+            };
+            content = {
+              type = "swap";
+              discardPolicy = "both";
+            };
+          };
+        };
+        root = {
+          size = "100%";
+          content = {
+            type = "luks";
+            name = "cryptroot";
+            settings = {
+              allowDiscards = true;
+              keyFile = "/dev/mapper/cryptkey";
+            };
+            content = {
+              type = "btrfs";
+              extraArgs = [ "-f" ];
+              subvolumes = {
+                "/root" = {
+                  mountpoint = "/";
+                  mountOptions = [
+                    "compress=zstd"
+                    "noatime"
+                  ];
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/configurations/nixos/kong/disko.nix
+++ b/configurations/nixos/kong/disko.nix
@@ -21,6 +21,11 @@
             type = "luks";
             name = "cryptkey";
             settings.allowDiscards = true;
+            content = {
+              type = "filesystem";
+              format = "ext4";
+              mountpoint = "/keyfile";
+            };
           };
         };
         swap = {
@@ -30,7 +35,7 @@
             name = "cryptswap";
             settings = {
               allowDiscards = true;
-              keyFile = "/dev/mapper/cryptkey";
+              keyFile = "/keyfile:/dev/mapper/cryptkey";
             };
             content = {
               type = "swap";
@@ -45,20 +50,16 @@
             name = "cryptroot";
             settings = {
               allowDiscards = true;
-              keyFile = "/dev/mapper/cryptkey";
+              keyFile = "/keyfile:/dev/mapper/cryptkey";
             };
             content = {
               type = "btrfs";
               extraArgs = [ "-f" ];
-              subvolumes = {
-                "/root" = {
-                  mountpoint = "/";
-                  mountOptions = [
-                    "compress=zstd"
-                    "noatime"
-                  ];
-                };
-              };
+              mountpoint = "/";
+              mountOptions = [
+                "compress=zstd"
+                "noatime"
+              ];
             };
           };
         };

--- a/configurations/nixos/kong/hardware-configuration.nix
+++ b/configurations/nixos/kong/hardware-configuration.nix
@@ -16,40 +16,11 @@
     };
     kernelModules = [ "kvm-intel" ];
     extraModulePackages = [ ];
-
-    initrd.luks.devices = {
-      cryptkey = {
-        device = "/dev/disk/by-uuid/4f764803-26f6-423a-a368-79bc41982937";
-      };
-
-      cryptroot = {
-        device = "/dev/disk/by-uuid/9a72ebca-706c-4166-a11a-a77877a9aa60";
-        keyFile = "/dev/mapper/cryptkey";
-      };
-
-      cryptswap = {
-        device = "/dev/disk/by-uuid/42f747bb-0c85-494d-8904-1b6e2863ee71";
-        keyFile = "/dev/mapper/cryptkey";
-      };
-    };
   };
-
-  fileSystems = {
-    "/" = {
-      device = "/dev/disk/by-uuid/12fe7f51-0695-4de6-9e5f-d55f22d7eaac";
-      fsType = "btrfs";
-    };
-
-    "/boot" = {
-      device = "/dev/disk/by-uuid/0E6A-4E5E";
-      fsType = "vfat";
-    };
-  };
-
-  swapDevices = [ { device = "/dev/disk/by-uuid/c164010e-34c8-4725-ac8f-95baa15839c6"; } ];
 
   nix.settings.max-jobs = lib.mkDefault 8;
   powerManagement.cpuFreqGovernor = lib.mkDefault "powersave";
+
   # High-DPI console
   console.font = lib.mkDefault "${pkgs.terminus_font}/share/consolefonts/ter-u28n.psf.gz";
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780894562,
+        "narHash": "sha256-c3430xwxwhHipl3jigUGMMBfpaMylDqytW/kdmB3ZGs=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "24fed06cac83bcc44ac8efbb57cab1a82fa0bedc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
     "elisp-helpers": {
       "inputs": {
         "fromElisp": "fromElisp"
@@ -228,6 +248,7 @@
     },
     "root": {
       "inputs": {
+        "disko": "disko",
         "emacs-config": "emacs-config",
         "flake-parts": "flake-parts",
         "home-manager": "home-manager",

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780894562,
-        "narHash": "sha256-c3430xwxwhHipl3jigUGMMBfpaMylDqytW/kdmB3ZGs=",
+        "lastModified": 1781152676,
+        "narHash": "sha256-RxWs5ND31KzTG7wvMM+PMfUjyNpmIEr999lqNARaM5o=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "24fed06cac83bcc44ac8efbb57cab1a82fa0bedc",
+        "rev": "ff8702b4de27f72b4c78573dfb89ec74e36abdf1",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780885330,
-        "narHash": "sha256-aMA5oAq2Iv467U9s8YOb50DYQT9w0WJbyWqwlzHuLMs=",
+        "lastModified": 1781189114,
+        "narHash": "sha256-5inaamLgUMWy+MOBE9ChF9QAF1o/74LFuHkI0W/9rqc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4fe95527cbe952713318ada8a4d122e1a6ab120f",
+        "rev": "486595d2cf49cfcd649b58a284fa11ac0e34da22",
         "type": "github"
       },
       "original": {
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780310866,
-        "narHash": "sha256-fPBRVf6A5xlACYcOI59shGrjURuvwu0lRsDoSCEXt/I=",
+        "lastModified": 1781168557,
+        "narHash": "sha256-LOnLQ2tpYF9gqIDDr3+j3DbpJJr/QCH6zPRT2GzEUOE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "4ed851c979641e28597a05086332d75cdc9e395f",
+        "rev": "6358ff76821101c178e3ab4919a62799bfe3652e",
         "type": "github"
       },
       "original": {
@@ -202,11 +202,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780895883,
-        "narHash": "sha256-y4ys7/dYufqXMIDH0qIC4C3Qkq7F+9syjlkz1vH7Apo=",
+        "lastModified": 1781160751,
+        "narHash": "sha256-dBIyf+gg33Fr1jdITRfENTALHUtMtLxBAyMqSq5ZGus=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0265069a40f500e713cbf64f29185b3cfa6c9ba9",
+        "rev": "e4ade1db48ff481708436f206a377be351a38974",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,10 @@
       url = "github:nix-community/nix-index-database";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    disko = {
+      url = "github:nix-community/disko";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/modules/home/profiles/user/terje/programs/mcp.nix
+++ b/modules/home/profiles/user/terje/programs/mcp.nix
@@ -20,12 +20,12 @@ in
         k8s = {
           type = "local";
           enabled = false;
-          command = [ "${pkgs.mcp-k8s-go}/bin/mcp-k8s-go" ];
+          command = "${pkgs.mcp-k8s-go}/bin/mcp-k8s-go";
         };
 
         nix = {
           type = "local";
-          command = [ "${pkgs.mcp-nixos}/bin/mcp-nixos" ];
+          command = "${pkgs.mcp-nixos}/bin/mcp-nixos";
         };
       };
     };


### PR DESCRIPTION
- Add disko flake input with nixpkgs follow
- Declare disk layout for kong: GPT, ESP, nested LUKS (cryptkey with
  password prompt unlocks cryptroot and cryptswap via keyfile),
  btrfs with /root subvolume, swap
- Trim hardware-configuration.nix to kernel modules only
  (filesystems, LUKS, swap now managed by disko)
- Add filesystem content to cryptkey LUKS so disko generates a
  fileSystems entry and systemd-cryptsetup can read the keyfile from
  a proper filesystem using path:device syntax
- Change keyFile syntax from /dev/mapper/cryptkey to
  /keyfile:/dev/mapper/cryptkey (systemd crypttab path:device format)
  required after nixpkgs dropped the systemd patch allowing block
  devices as keyfiles ([PR #488508](https://github.com/NixOS/nixpkgs/pull/488508))
- Drop /root subvolume from disko, mount btrfs top-level directly
  to match existing filesystem layout; the old system used the
  top-level subvolume so /root did not exist, causing the mount to
  fail and dropping into systemd emergency mode
- Add boot.initrd.supportedFilesystems and checkJournalingFS for ext4
  support in initrd, needed to mount the cryptkey filesystem during
  early boot