### PR TITLE
chore(home): bump opencode ponytail and superpowers skills

### DIFF
--- a/modules/home/profiles/user/terje/programs/opencode/default.nix
+++ b/modules/home/profiles/user/terje/programs/opencode/default.nix
@@ -12,15 +12,15 @@ let
   ponytail = pkgs.fetchFromGitHub {
     owner = "DietrichGebert";
     repo = "ponytail";
-    rev = "v4.8.4";
-    hash = "sha256-1A9GkjCuiqwd6Wxl18CZUGYekxrbeTLVDapNUua8ihg=";
+    rev = "v4.9.0";
+    hash = "sha256-8cYggVltBAlZ/Zj4pl1bOu7mQdZFXCmDGW4RSpvRA+w=";
   };
 
   superpowersSrc = pkgs.fetchFromGitHub {
     owner = "obra";
     repo = "superpowers";
-    rev = "v5.1.0";
-    hash = "sha256-3E3rO6hR87JUfS3XV1Eaoz6SDWOftleWvN9UPNFEMjw=";
+    rev = "v6.2.0";
+    hash = "sha256-F5LEk0yNWbMpan1vZSFZM76XSpsFGvA7h8q6Idrvenk=";
   };
 in
 {


### PR DESCRIPTION
- Bump ponytail plugin to v4.9.0
- Bump superpowers skills to v6.2.0