### PR TITLE
feat(home): add gopls, bashls, and biome LSP servers

### DIFF
--- a/modules/home/profiles/user/terje/programs/opencode/default.nix
+++ b/modules/home/profiles/user/terje/programs/opencode/default.nix
@@ -108,6 +108,39 @@ in
               ".yml"
             ];
           };
+
+          gopls = {
+            command = [ (lib.getExe pkgs.gopls) ];
+            extensions = [
+              ".go"
+              ".mod"
+              ".sum"
+            ];
+          };
+
+          bashls = {
+            command = [
+              (lib.getExe pkgs.bash-language-server)
+              "start"
+            ];
+            extensions = [
+              ".sh"
+              ".bash"
+            ];
+          };
+
+          biome = {
+            command = [
+              (lib.getExe pkgs.biome)
+              "lsp-proxy"
+            ];
+            extensions = [
+              ".js"
+              ".ts"
+              ".jsx"
+              ".tsx"
+            ];
+          };
         };
       };
     };


### PR DESCRIPTION
Add missing LSP servers to OpenCode configuration:
- gopls: Go language server (.go, .mod, .sum)
- bashls: Bash language server (.sh, .bash)
- biome: JavaScript/TypeScript toolchain (.js, .ts, .jsx, .tsx)